### PR TITLE
Form deprecation fix.

### DIFF
--- a/classes/form/integer.php
+++ b/classes/form/integer.php
@@ -74,13 +74,21 @@ class block_stash_form_integer extends MoodleQuickForm_group {
     function _createElements() {
         $attributes = (array) $this->getAttributes();
 
-        $element = @MoodleQuickForm::createElement('text', 'int', get_string('number', 'block_stash'), $attributes);
+        if (method_exists($this, 'createFormElement')) {
+            $element = $this->createFormElement('text', 'int', get_string('number', 'block_stash'), $attributes);
+        } else {
+            $element = @MoodleQuickForm::createElement('text', 'int', get_string('number', 'block_stash'), $attributes);
+        }
         $element->setType('number');
         $element->setHiddenLabel(true);
 
         $this->_elements = [];
         $this->_elements[] = $element;
-        $this->_elements[] = @MoodleQuickForm::createElement('checkbox', 'unl', null, get_string('unlimited', 'block_stash'));
+        if (method_exists($this, 'createFormElement')) {
+            $this->_elements[] = $this->createFormElement('checkbox', 'unl', null, get_string('unlimited', 'block_stash'));
+        } else {
+            $this->_elements[] = @MoodleQuickForm::createElement('checkbox', 'unl', null, get_string('unlimited', 'block_stash'));
+        }
     }
 
     /**
@@ -108,6 +116,9 @@ class block_stash_form_integer extends MoodleQuickForm_group {
      * @return bool
      */
     function onQuickFormEvent($event, $arg, &$caller) {
+        if (method_exists($this, 'setMoodleForm')) {
+            $this->setMoodleForm($caller);
+        }
         switch ($event) {
             case 'updateValue':
                 $value = $this->_findValue($caller->_constantValues);


### PR DESCRIPTION
We are getting the following deprecation message:
Function createElement() can not be called statically, this will no longer work in PHP 7.1
Here is a patch to fix that issue.